### PR TITLE
Fix remove extra call and early return of empty items checking

### DIFF
--- a/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
+++ b/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
@@ -392,6 +392,10 @@ extension UnsplashPhotoPickerViewController: PagedDataSourceDelegate {
 
             return
         }
+        
+        guard !items.isEmpty else {
+            return
+        }
 
         let newPhotosCount = items.count
         let startIndex = self.dataSource.items.count - newPhotosCount

--- a/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
+++ b/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
@@ -384,7 +384,7 @@ extension UnsplashPhotoPickerViewController: PagedDataSourceDelegate {
     }
 
     func dataSource(_ dataSource: PagedDataSource, didFetch items: [UnsplashPhoto]) {
-        guard !items.isEmpty else {
+        guard !dataSource.items.isEmpty else {
             DispatchQueue.main.async {
                 self.spinner.stopAnimating()
                 self.showEmptyView(with: .noResults)

--- a/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
+++ b/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
@@ -384,8 +384,7 @@ extension UnsplashPhotoPickerViewController: PagedDataSourceDelegate {
     }
 
     func dataSource(_ dataSource: PagedDataSource, didFetch items: [UnsplashPhoto]) {
-        guard items.count > 0 else { return }
-        guard dataSource.items.count > 0 else {
+        guard !items.isEmpty else {
             DispatchQueue.main.async {
                 self.spinner.stopAnimating()
                 self.showEmptyView(with: .noResults)


### PR DESCRIPTION
# What does this PR do?

Addresses [CAPP-2369](https://linear.app/craft-docs/issue/CAPP-2369/unsplash-component-missing-empty-state).